### PR TITLE
CMAKE: Force evaluation of HEADERONLY parameter

### DIFF
--- a/cmake/macros.cmake
+++ b/cmake/macros.cmake
@@ -496,7 +496,7 @@ macro(cp_find LIB HEADER SUFFIX HEADERONLY VERSION)
 					${${PKG_PREFIX}_INCLUDE_DIRS}}
 					${_SEARCH_PATHS}
 			)
-			if (NOT HEADERONLY)
+			if (NOT ${HEADERONLY})
 				find_library(${PREFIX}_LIBRARIES
 					NAMES ${LIB}
 					HINTS ENV ${PREFIX}DIR
@@ -507,7 +507,7 @@ macro(cp_find LIB HEADER SUFFIX HEADERONLY VERSION)
 				)
 			endif()
 			include(FindPackageHandleStandardArgs)
-			if (HEADERONLY)
+			if (${HEADERONLY})
 				message(STATUS "Header only lib ${LIB}")
 				set(${PREFIX}_LIBRARIES "")
 				find_package_handle_standard_args(${LIB} DEFAULT_MSG ${PREFIX}_INCLUDE_DIRS)


### PR DESCRIPTION
Somehow the  part would not be triggered without it,
ending up with system glm not being detected properly on Linux.

I'm not 100% sure I understood why it did not work, but the patch fixes the detection of glm for me. (An initial guess was that the HEADERONLY var might be seen as a string, and thus not evaluated as a bool without the `${}` operator; but then it should have always been true, since strings are not a false constant).