### PR TITLE
gameplay: allow diving

### DIFF
--- a/src/caveexpress/server/map/Map.cpp
+++ b/src/caveexpress/server/map/Map.cpp
@@ -3,6 +3,7 @@
 #include "common/MapSettings.h"
 #include "common/Shared.h"
 #include "caveexpress/shared/constants/Commands.h"
+#include "caveexpress/shared/constants/Density.h"
 #include "common/Log.h"
 #include "service/ServiceProvider.h"
 #include "common/SpriteDefinition.h"
@@ -1493,7 +1494,8 @@ bool Map::visitEntity (IEntity *entity)
 	if (_time >= _warmupPhase) {
 		entity->update(Constant::DELTA_PHYSICS_MILLIS);
 		if (entity->shouldApplyWind())
-			entity->applyLinearImpulse(b2Vec2(_wind, 0.0f));
+			entity->applyLinearImpulse(b2Vec2(_wind * (DENSITY_PLAYER / 400.0f), 0.0f));
+			// entity->applyLinearImpulse(b2Vec2(_wind * entity->getMass() / 200.f, 0.0f));  // acceleration?
 	}
 	handleVisibility(entity, vismask);
 

--- a/src/caveexpress/shared/constants/Density.h
+++ b/src/caveexpress/shared/constants/Density.h
@@ -8,11 +8,11 @@ namespace caveexpress {
 #define DENSITY_NPC_FISH		550.0f
 #define DENSITY_STONE			2400.0f
 #define DENSITY_BOMB			1200.0f
-#define DENSITY_PACKAGE			500.0f
+#define DENSITY_PACKAGE			800.0f   // 500.0f  old, no diving
 #define DENSITY_TREE			450.0f
 #define DENSITY_FRUIT			350.0f
 #define DENSITY_EGG				500.0f
-#define DENSITY_PLAYER			1000.0f  // 400.0f old, no diving
+#define DENSITY_PLAYER			1000.0f  // 400.0f  old, no diving
 #define DENSITY_AIR				1.2041f
 #define DENSITY_PACKAGETARGET	450.0f
 #define DENSITY_BRIDGE			1000.0f

--- a/src/caveexpress/shared/constants/Density.h
+++ b/src/caveexpress/shared/constants/Density.h
@@ -12,7 +12,7 @@ namespace caveexpress {
 #define DENSITY_TREE			450.0f
 #define DENSITY_FRUIT			350.0f
 #define DENSITY_EGG				500.0f
-#define DENSITY_PLAYER			400.0f
+#define DENSITY_PLAYER			1000.0f  // 400.0f old, no diving
 #define DENSITY_AIR				1.2041f
 #define DENSITY_PACKAGETARGET	450.0f
 #define DENSITY_BRIDGE			1000.0f


### PR DESCRIPTION
now DENSITY_PLAYER 1000
This allows diving, not too deep. But fun gameplay element.
Was present in Ugh and used on few maps. Which I would also sometimes use in new maps.

But this now allows carrying even 4 packages. I personally like this, makes gameplay faster.
Not sure if you want this, if not, need to tweek DENSITY_PACKAGE (probably close to 1000 too).