### PR TITLE
gameplay: fast NPC drop

### DIFF
--- a/src/caveexpress/server/entities/Platform.cpp
+++ b/src/caveexpress/server/entities/Platform.cpp
@@ -43,20 +43,23 @@ void Platform::onPreSolve (b2Contact* contact, IEntity* entity, const b2Manifold
 	b2WorldManifold worldManifold;
 	contact->GetWorldManifold(&worldManifold);
 	const b2Vec2 worldNormal = worldManifold.normal;
-	// not from above - then we don't care
-	// -1/sqrt(2)
-	if (worldNormal.y >= -0.707)
+	// not from above - then we don't care	// -1/sqrt(2)
+	// if (worldNormal.y >= -0.707)  // old
+	// 	return;
+	if (worldNormal.y >= -0.07 ||
+		fabs(worldNormal.x) > fabs(worldNormal.y))
 		return;
 
 	const b2Manifold *maniFold = contact->GetManifold();
-	if (maniFold->pointCount < 2)
-		return;
+	// if (maniFold->pointCount < 2)  // old
+	// 	return;
 
 	const float normalImpulse = maniFold->points[0].normalImpulse;
 	const float absNormalImpulse = fabs(normalImpulse);
 	if (absNormalImpulse < EPSILON)
 		return;
 
+	/* old
 	for (int i = 0; i < maniFold->pointCount; i++) {
 		// shut up compiler
 		if (i == 0)
@@ -65,7 +68,7 @@ void Platform::onPreSolve (b2Contact* contact, IEntity* entity, const b2Manifold
 		const float impulse = fabs(normalImpulse - maniFold->points[i].normalImpulse);
 		if (impulse > 5.0f)
 			return;
-	}
+	}*/
 	player->setPlatform(this);
 	Log::debug(LOG_GAMEIMPL, "player %s (%i) landed on cave %i", player->getName().c_str(), player->getID(), getID());
 }

--- a/src/caveexpress/server/entities/Platform.cpp
+++ b/src/caveexpress/server/entities/Platform.cpp
@@ -44,31 +44,16 @@ void Platform::onPreSolve (b2Contact* contact, IEntity* entity, const b2Manifold
 	contact->GetWorldManifold(&worldManifold);
 	const b2Vec2 worldNormal = worldManifold.normal;
 	// not from above - then we don't care	// -1/sqrt(2)
-	// if (worldNormal.y >= -0.707)  // old
-	// 	return;
 	if (worldNormal.y >= -0.07 ||
 		fabs(worldNormal.x) > fabs(worldNormal.y))
 		return;
 
 	const b2Manifold *maniFold = contact->GetManifold();
-	// if (maniFold->pointCount < 2)  // old
-	// 	return;
-
 	const float normalImpulse = maniFold->points[0].normalImpulse;
 	const float absNormalImpulse = fabs(normalImpulse);
 	if (absNormalImpulse < EPSILON)
 		return;
 
-	/* old
-	for (int i = 0; i < maniFold->pointCount; i++) {
-		// shut up compiler
-		if (i == 0)
-			continue;
-		// the impulses must match - otherwise we are not in rest
-		const float impulse = fabs(normalImpulse - maniFold->points[i].normalImpulse);
-		if (impulse > 5.0f)
-			return;
-	}*/
 	player->setPlatform(this);
 	Log::debug(LOG_GAMEIMPL, "player %s (%i) landed on cave %i", player->getName().c_str(), player->getID(), getID());
 }

--- a/src/caveexpress/server/entities/Platform.cpp
+++ b/src/caveexpress/server/entities/Platform.cpp
@@ -49,6 +49,8 @@ void Platform::onPreSolve (b2Contact* contact, IEntity* entity, const b2Manifold
 		return;
 
 	const b2Manifold *maniFold = contact->GetManifold();
+	if (maniFold->pointCount <= 0)
+		return;
 	const float normalImpulse = maniFold->points[0].normalImpulse;
 	const float absNormalImpulse = fabs(normalImpulse);
 	if (absNormalImpulse < EPSILON)

--- a/src/caveexpress/server/entities/Player.cpp
+++ b/src/caveexpress/server/entities/Player.cpp
@@ -590,9 +590,6 @@ bool Player::isCloseOverSolid (float distance) const
 
 bool Player::isLanded () const
 {
-	// if (!b2Vec2Equals(getLinearVelocity(), b2Vec2_zero))  // old
-	// 	return false;
-
 	if (isCloseOverSolid())
 		return true;
 

--- a/src/caveexpress/server/entities/Player.cpp
+++ b/src/caveexpress/server/entities/Player.cpp
@@ -590,8 +590,8 @@ bool Player::isCloseOverSolid (float distance) const
 
 bool Player::isLanded () const
 {
-	if (!b2Vec2Equals(getLinearVelocity(), b2Vec2_zero))
-		return false;
+	// if (!b2Vec2Equals(getLinearVelocity(), b2Vec2_zero))  // old
+	// 	return false;
 
 	if (isCloseOverSolid())
 		return true;

--- a/src/caveexpress/server/entities/npcs/NPCFriendly.cpp
+++ b/src/caveexpress/server/entities/npcs/NPCFriendly.cpp
@@ -82,9 +82,9 @@ bool NPCFriendly::triggerTargetCaveAnnouncement (const b2Vec2& playerPos)
 		return false;
 	}
 	if (_triggerMovement == 0) {
-		_triggerMovement = _time + 600;
-		GameEvent.announceTargetCave(getVisMask(), *this, 1200);
-		return false;
+		_triggerMovement = _time + 200;  // 600
+		GameEvent.announceTargetCave(getVisMask(), *this, 1400);  // 1200
+		return true;  // false;
 	}
 	return _time > _triggerMovement;
 }
@@ -168,6 +168,7 @@ void NPCFriendly::update (uint32_t deltaTime)
 	if (targetCave != nullptr && targetCave->isUnderWater()) {
 		CaveMapTile *cave = _map.getTargetCave(getCave());
 		if (cave == nullptr) {
+			Log::warn(LOG_GAMEIMPL, "NO target CAVE, restart map ---");
 			_map.restart(2000);
 			return;
 		}

--- a/src/caveexpress/server/entities/npcs/NPCFriendly.cpp
+++ b/src/caveexpress/server/entities/npcs/NPCFriendly.cpp
@@ -82,9 +82,9 @@ bool NPCFriendly::triggerTargetCaveAnnouncement (const b2Vec2& playerPos)
 		return false;
 	}
 	if (_triggerMovement == 0) {
-		_triggerMovement = _time + 200;  // 600
-		GameEvent.announceTargetCave(getVisMask(), *this, 1400);  // 1200
-		return true;  // false;
+		_triggerMovement = _time + 200;
+		GameEvent.announceTargetCave(getVisMask(), *this, 1400);
+		return true;
 	}
 	return _time > _triggerMovement;
 }


### PR DESCRIPTION
Fixes this annoying bug when I land on platform and nothing happes, NPC stands still, because I didn't land (IMO way too) perfectly and I have to start and land again which is frustrating and not playable.
So this IMO fixes the sluggish Taxi gameplay. I'd like this instead, it's way better for all of taxi maps I add. NPCs feel quicker too.