### PR TITLE
don't fail map if no NPCs are visible, fixes taxi-04 with 3 transfers

### DIFF
--- a/src/caveexpress/server/entities/npcs/NPC.cpp
+++ b/src/caveexpress/server/entities/npcs/NPC.cpp
@@ -302,6 +302,9 @@ void NPC::setDying (const IEntity* entity)
 	if (EntityTypes::isNpcAggressive(_type)) {
 		_map.addPoints(entity, 15);
 	}
+	if (isNpcFriendly()) {
+		_map.addKilledNPC();
+	}
 }
 
 void NPC::setState (int state)

--- a/src/caveexpress/server/map/Map.cpp
+++ b/src/caveexpress/server/map/Map.cpp
@@ -355,14 +355,16 @@ bool Map::isFailed () const
 	if (_players.empty())
 		return true;
 
+	/* old, bad
 	if (_friendlyNPCLimit > 0) {
 		// if we support friendly npcs in this map, and all of them are (or were) already spawned,
 		// but none is available anymore, this map is lost
 		if (_friendlyNPCCount >= _friendlyNPCLimit) {
 			if (_friendlyNPCs.empty())
+				Log::warn(LOG_GAMEIMPL, "failed because of no NPCs....");
 				return true;
 		}
-	}
+	}*/
 
 	for (PlayerListConstIter i = _players.begin(); i != _players.end(); ++i) {
 		const Player* player = *i;

--- a/src/caveexpress/server/map/Map.cpp
+++ b/src/caveexpress/server/map/Map.cpp
@@ -355,17 +355,6 @@ bool Map::isFailed () const
 	if (_players.empty())
 		return true;
 
-	/* old, bad
-	if (_friendlyNPCLimit > 0) {
-		// if we support friendly npcs in this map, and all of them are (or were) already spawned,
-		// but none is available anymore, this map is lost
-		if (_friendlyNPCCount >= _friendlyNPCLimit) {
-			if (_friendlyNPCs.empty())
-				Log::warn(LOG_GAMEIMPL, "failed because of no NPCs....");
-				return true;
-		}
-	}*/
-
 	for (PlayerListConstIter i = _players.begin(); i != _players.end(); ++i) {
 		const Player* player = *i;
 		if (!player->isCrashed()) {

--- a/src/caveexpress/server/map/Map.cpp
+++ b/src/caveexpress/server/map/Map.cpp
@@ -127,6 +127,11 @@ void Map::shutdown ()
 	resetCurrentMap();
 }
 
+void Map::addKilledNPC ()
+{
+	++_friendlyNPCKilled;
+}
+
 void Map::addPoints (const IEntity* entity, uint16_t points)
 {
 	if (entity == nullptr)
@@ -354,6 +359,18 @@ bool Map::isFailed () const
 
 	if (_players.empty())
 		return true;
+	
+	if (_friendlyNPCLimit > 0) {
+		// if we support friendly npcs in this map, and all of them are (or were) already spawned,
+		// but none is available anymore, this map is lost
+		if (_friendlyNPCCount >= _friendlyNPCLimit) {
+			if (_friendlyNPCKilled >= _friendlyNPCCount)
+			{
+				Log::warn(LOG_GAMEIMPL, "failed because of all NPCs killed....");
+				return true;
+			}
+		}
+	}
 
 	for (PlayerListConstIter i = _players.begin(); i != _players.end(); ++i) {
 		const Player* player = *i;
@@ -449,6 +466,7 @@ void Map::resetCurrentMap ()
 	_activateflyingNPC = false;
 	_friendlyNPCLimit = 0;
 	_friendlyNPCCount = 0;
+	_friendlyNPCKilled = 0;
 	_caveCounter = 0;
 	_spawnFishNPCTime = 0;
 	_initialGeyserDelay = 0;

--- a/src/caveexpress/server/map/Map.h
+++ b/src/caveexpress/server/map/Map.h
@@ -150,6 +150,8 @@ protected:
 	uint32_t _transferedNPCLimit;
 	// the already spawned friendly npcs
 	uint32_t _friendlyNPCCount;
+	// how many killed by player
+	uint32_t _friendlyNPCKilled;
 	// the max amount to spawn (they can die)
 	uint32_t _friendlyNPCLimit;
 	uint32_t _caveCounter;
@@ -306,6 +308,8 @@ public:
 	void countTransferedNPC();
 	// this is the amount of npcs that you still have to transfered to other caves in order to win the game
 	int getNpcCount() const;
+
+	void addKilledNPC ();
 
 	// increases the counter for the successfully performed transfers
 	void countTransferedPackage ();


### PR DESCRIPTION
This fixes taxi-04 properly and all other taxi map issues: if NPCs arent visible (hidden in caves) map will fail, with no reason, this was a bug.
Feel free to restore taxi-04, it will work now, with 3 transfers as before. https://github.com/mgerhardy/caveexpress/commit/5cac237ee5b77d9b032057a346ba15b0c5d41d13