### PR TITLE
UI Maps and Campaign view 6x4, bigger fonts

### DIFF
--- a/src/modules/ui/nodes/UINodeCampaignSelector.cpp
+++ b/src/modules/ui/nodes/UINodeCampaignSelector.cpp
@@ -8,7 +8,7 @@ UINodeCampaignSelector::UINodeCampaignSelector (IFrontend *frontend, CampaignMan
 {
 	defaults();
 	setPaddingPixel(10);
-	setColsRowsFromTexture("icon-campaign");
+	// setColsRowsFromTexture("icon-campaign");
 	reset();
 }
 
@@ -39,9 +39,10 @@ void UINodeCampaignSelector::renderSelectorEntry (int index, const CampaignPtr& 
 		t = loadTexture("icon-campaign");
 
 	if (!data->getText().empty()) {
-		const BitmapFontPtr& font = getFont(SMALL_FONT);
+		const BitmapFontPtr& font = getFont(HUGE_FONT); //SMALL_FONT);
 		const int textHeight = font->getTextHeight(data->getText());
-		const int fontX = std::max(x, x + colWidth / 2 - font->getTextWidth(data->getText()) / 2);
+		// const int fontX = std::max(x, x + colWidth / 2 - font->getTextWidth(data->getText()) / 2);  // center
+		const int fontX = x;  // left
 		const int fontY = y + rowHeight - textHeight - 1;
 		_frontend->renderFilledRect(x, fontY - 1, colWidth, textHeight + 2, colorBlack);
 		//_frontend->renderRect(x, fontY - 1, colWidth, textHeight + 2, colorWhite);

--- a/src/modules/ui/nodes/UINodeCampaignSelector.cpp
+++ b/src/modules/ui/nodes/UINodeCampaignSelector.cpp
@@ -38,6 +38,7 @@ void UINodeCampaignSelector::renderSelectorEntry (int index, const CampaignPtr& 
 	if (!t || !t->isValid())
 		t = loadTexture("icon-campaign");
 
+	const int margX = 35;
 	if (!data->getText().empty()) {
 		const BitmapFontPtr& font = getFont(HUGE_FONT); //SMALL_FONT);
 		const int textHeight = font->getTextHeight(data->getText());
@@ -46,10 +47,10 @@ void UINodeCampaignSelector::renderSelectorEntry (int index, const CampaignPtr& 
 		const int fontY = y + rowHeight - textHeight - 1;
 		_frontend->renderFilledRect(x, fontY - 1, colWidth, textHeight + 2, colorBlack);
 		//_frontend->renderRect(x, fontY - 1, colWidth, textHeight + 2, colorWhite);
-		renderImage(t, x, y, colWidth, rowHeight - textHeight, alpha);
+		renderImage(t, x + margX, y, colWidth - 2*margX, rowHeight - textHeight, alpha);
 		font->printMax(data->getText(), colorWhite, fontX, fontY, colWidth);
 	} else {
-		renderImage(t, x, y, colWidth, rowHeight, alpha);
+		renderImage(t, x + margX, y, colWidth - 2*margX, rowHeight, alpha);
 	}
 }
 

--- a/src/modules/ui/nodes/UINodeCampaignSelector.cpp
+++ b/src/modules/ui/nodes/UINodeCampaignSelector.cpp
@@ -38,19 +38,19 @@ void UINodeCampaignSelector::renderSelectorEntry (int index, const CampaignPtr& 
 	if (!t || !t->isValid())
 		t = loadTexture("icon-campaign");
 
-	const int margX = 35;
+	const int marginX = 35, padding = 20, marginXtotal = 2 * marginX + padding;
 	if (!data->getText().empty()) {
+
 		const BitmapFontPtr& font = getFont(HUGE_FONT); //SMALL_FONT);
 		const int textHeight = font->getTextHeight(data->getText());
-		// const int fontX = std::max(x, x + colWidth / 2 - font->getTextWidth(data->getText()) / 2);  // center
-		const int fontX = x;  // left
-		const int fontY = y + rowHeight - textHeight - 1;
-		_frontend->renderFilledRect(x, fontY - 1, colWidth, textHeight + 2, colorBlack);
-		//_frontend->renderRect(x, fontY - 1, colWidth, textHeight + 2, colorWhite);
-		renderImage(t, x + margX, y, colWidth - 2*margX, rowHeight - textHeight, alpha);
+		const int fontX = x;
+		const int fontY = y + rowHeight - textHeight - 1 - padding;
+		
+		_frontend->renderFilledRect(x, fontY - 1, colWidth - padding, textHeight + 2, colorBlack);
+		renderImage(t, x + marginX, y, colWidth - marginXtotal, rowHeight - textHeight - padding, alpha);
 		font->printMax(data->getText(), colorWhite, fontX, fontY, colWidth);
 	} else {
-		renderImage(t, x + margX, y, colWidth - 2*margX, rowHeight, alpha);
+		renderImage(t, x + marginX, y, colWidth - marginXtotal, rowHeight - padding, alpha);
 	}
 }
 

--- a/src/modules/ui/nodes/UINodeCampaignSelector.cpp
+++ b/src/modules/ui/nodes/UINodeCampaignSelector.cpp
@@ -43,7 +43,7 @@ void UINodeCampaignSelector::renderSelectorEntry (int index, const CampaignPtr& 
 
 		const BitmapFontPtr& font = getFont(HUGE_FONT);
 		const int textHeight = font->getTextHeight(data->getText());
-		const int fontX = std::max(x, x - padding / 2 + colWidth / 2 - font->getTextWidth(data->getText()) / 2);  // center
+		const int fontX = std::max(x, x + colWidth / 2 - font->getTextWidth(data->getText()) / 2 - padding / 2 );
 		const int fontY = y + rowHeight - textHeight - 1 - padding;
 		
 		_frontend->renderFilledRect(x, fontY - 1, colWidth - padding, textHeight + 2, colorBlack);

--- a/src/modules/ui/nodes/UINodeCampaignSelector.cpp
+++ b/src/modules/ui/nodes/UINodeCampaignSelector.cpp
@@ -41,9 +41,9 @@ void UINodeCampaignSelector::renderSelectorEntry (int index, const CampaignPtr& 
 	const int marginX = 35, padding = 20, marginXtotal = 2 * marginX + padding;
 	if (!data->getText().empty()) {
 
-		const BitmapFontPtr& font = getFont(HUGE_FONT); //SMALL_FONT);
+		const BitmapFontPtr& font = getFont(HUGE_FONT);
 		const int textHeight = font->getTextHeight(data->getText());
-		const int fontX = x;
+		const int fontX = std::max(x, x - padding / 2 + colWidth / 2 - font->getTextWidth(data->getText()) / 2);  // center
 		const int fontY = y + rowHeight - textHeight - 1 - padding;
 		
 		_frontend->renderFilledRect(x, fontY - 1, colWidth - padding, textHeight + 2, colorBlack);

--- a/src/modules/ui/nodes/UINodeMapSelector.cpp
+++ b/src/modules/ui/nodes/UINodeMapSelector.cpp
@@ -8,7 +8,7 @@
 UINodeMapSelector::UINodeMapSelector (IFrontend *frontend, const IMapManager &mapManager, bool multiplayer, int cols, int rows) :
 		UINodeBackgroundSelector<std::string>(frontend, cols, rows), _campaignManager(nullptr), _mapManager(&mapManager), _multiplayer(multiplayer)
 {
-	setColsRowsFromTexture("map-icon-locked");
+	// setColsRowsFromTexture("map-icon-locked");
 	defaults();
 	setPaddingPixel(10);
 	reset();
@@ -18,7 +18,7 @@ UINodeMapSelector::UINodeMapSelector (IFrontend *frontend, CampaignManager &camp
 		UINodeBackgroundSelector<std::string>(frontend, cols, rows), _campaignManager(&campaignManager), _mapManager(
 				nullptr), _multiplayer(multiplayer)
 {
-	setColsRowsFromTexture("map-icon-locked");
+	// setColsRowsFromTexture("map-icon-locked");
 	defaults();
 	setPaddingPixel(10);
 	reset();
@@ -67,11 +67,11 @@ void UINodeMapSelector::renderSelectorEntry (int index, const std::string& data,
 		const CampaignPtr& campaignPtr = _campaignManager->getActiveCampaign();
 		const CampaignMap *map = campaignPtr->getMapById(data);
 		if (map != nullptr && !map->isLocked()) {
-			const BitmapFontPtr& font = getFont(MEDIUM_FONT);
+			const BitmapFontPtr& font = getFont(LARGE_FONT);  // MEDIUM_FONT);
 			const std::string points = string::toString(map->getFinishPoints());
 			const int fontX = std::max(x, x + colWidth / 2 - font->getTextWidth(points) / 2);
-			const int fontHeight = font->getTextHeight(points);
-			const int fontY = y + fontHeight;
+			const int fontHeight = 22;  // font->getTextHeight(points);
+			const int fontY = y;  // + fontHeight;
 			if (t)
 				renderImage(t, x, y, colWidth, rowHeight - fontHeight, alpha);
 			font->printMax(points, colorWhite, fontX, fontY, colWidth);
@@ -86,9 +86,12 @@ void UINodeMapSelector::renderSelectorEntry (int index, const std::string& data,
 		return;*/
 
 	if (!title.empty()) {
-		const BitmapFontPtr& font = getFont(SMALL_FONT);
+		const BitmapFontPtr& font = getFont(title.length() > 15
+			? MEDIUM_FONT : HUGE_FONT);
+			// ? SMALL_FONT : MEDIUM_FONT);
 		const int textHeight = font->getTextHeight(title);
-		const int fontX = std::max(x, x + colWidth / 2 - font->getTextWidth(title) / 2);
+		// const int fontX = std::max(x, x + colWidth / 2 - font->getTextWidth(title) / 2);  // center
+		const int fontX = x;  // left
 		const int fontY = y + rowHeight - textHeight - 1;
 		_frontend->renderFilledRect(x, fontY - 1, colWidth, textHeight + 2, colorBlack);
 		//_frontend->renderRect(x, fontY - 1, colWidth, textHeight + 2, colorWhite);

--- a/src/modules/ui/nodes/UINodeMapSelector.cpp
+++ b/src/modules/ui/nodes/UINodeMapSelector.cpp
@@ -62,25 +62,26 @@ void UINodeMapSelector::renderSelectorEntry (int index, const std::string& data,
 		title = map->getName();
 	}
 
-	const int margX = 35;
+	const int marginX = 25, padding = 20, marginXtotal = 2 * marginX + padding;
 	const TexturePtr t = getIcon(data);
 	if (_campaignManager != nullptr) {
 		const CampaignPtr& campaignPtr = _campaignManager->getActiveCampaign();
 		const CampaignMap *map = campaignPtr->getMapById(data);
 		if (map != nullptr && !map->isLocked()) {
+
 			const BitmapFontPtr& font = getFont(LARGE_FONT);  // MEDIUM_FONT);
 			const std::string points = string::toString(map->getFinishPoints());
-			const int fontX = std::max(x, x + colWidth / 2 - font->getTextWidth(points) / 2);
-			const int fontHeight = 22;  // font->getTextHeight(points);
-			const int fontY = y;  // + fontHeight;
+			const int fontX = std::max(x, x + colWidth / 2 - font->getTextWidth(points) / 2 - padding / 2);
+			const int fontHeight = 22;
+			const int fontY = y;
 			if (t)
-				renderImage(t, x + margX, y, colWidth - 2*margX, rowHeight - fontHeight, alpha);
+				renderImage(t, x + marginX, y, colWidth - marginXtotal, rowHeight - fontHeight - padding, alpha);
 			font->printMax(points, colorWhite, fontX, fontY, colWidth);
 		} else if (t) {
-			renderImage(t, x + margX, y, colWidth - 2*margX, rowHeight, alpha);
+			renderImage(t, x + marginX, y, colWidth - marginXtotal, rowHeight - padding, alpha);
 		}
 	} else if (t) {
-		renderImage(t, x + margX, y, colWidth - 2*margX, rowHeight, alpha);
+		renderImage(t, x + marginX, y, colWidth - marginXtotal, rowHeight - padding, alpha);
 	}
 
 /*	if (_selectedIndex != index)
@@ -93,8 +94,9 @@ void UINodeMapSelector::renderSelectorEntry (int index, const std::string& data,
 		const int textHeight = font->getTextHeight(title);
 		// const int fontX = std::max(x, x + colWidth / 2 - font->getTextWidth(title) / 2);  // center
 		const int fontX = x;  // left
-		const int fontY = y + rowHeight - textHeight - 1;
-		_frontend->renderFilledRect(x, fontY - 1, colWidth, textHeight + 2, colorBlack);
+		const int fontY = y + rowHeight - textHeight - 1 - padding;
+		
+		_frontend->renderFilledRect(x, fontY - 1, colWidth - padding, textHeight + 2, colorBlack);
 		//_frontend->renderRect(x, fontY - 1, colWidth, textHeight + 2, colorWhite);
 		font->printMax(title, colorWhite, fontX, fontY, colWidth);
 	}

--- a/src/modules/ui/nodes/UINodeMapSelector.cpp
+++ b/src/modules/ui/nodes/UINodeMapSelector.cpp
@@ -62,6 +62,7 @@ void UINodeMapSelector::renderSelectorEntry (int index, const std::string& data,
 		title = map->getName();
 	}
 
+	const int margX = 35;
 	const TexturePtr t = getIcon(data);
 	if (_campaignManager != nullptr) {
 		const CampaignPtr& campaignPtr = _campaignManager->getActiveCampaign();
@@ -73,13 +74,13 @@ void UINodeMapSelector::renderSelectorEntry (int index, const std::string& data,
 			const int fontHeight = 22;  // font->getTextHeight(points);
 			const int fontY = y;  // + fontHeight;
 			if (t)
-				renderImage(t, x, y, colWidth, rowHeight - fontHeight, alpha);
+				renderImage(t, x + margX, y, colWidth - 2*margX, rowHeight - fontHeight, alpha);
 			font->printMax(points, colorWhite, fontX, fontY, colWidth);
 		} else if (t) {
-			renderImage(t, x, y, colWidth, rowHeight, alpha);
+			renderImage(t, x + margX, y, colWidth - 2*margX, rowHeight, alpha);
 		}
 	} else if (t) {
-		renderImage(t, x, y, colWidth, rowHeight, alpha);
+		renderImage(t, x + margX, y, colWidth - 2*margX, rowHeight, alpha);
 	}
 
 /*	if (_selectedIndex != index)

--- a/src/modules/ui/nodes/UINodeMapSelector.cpp
+++ b/src/modules/ui/nodes/UINodeMapSelector.cpp
@@ -71,7 +71,7 @@ void UINodeMapSelector::renderSelectorEntry (int index, const std::string& data,
 
 			const BitmapFontPtr& font = getFont(LARGE_FONT);  // MEDIUM_FONT);
 			const std::string points = string::toString(map->getFinishPoints());
-			const int fontX = std::max(x, x + colWidth / 2 - font->getTextWidth(points) / 2 - padding / 2);
+			const int fontX = std::max(x, x - padding / 2 + colWidth / 2 - font->getTextWidth(points) / 2 - padding / 2);
 			const int fontHeight = 22;
 			const int fontY = y;
 			if (t)
@@ -88,12 +88,9 @@ void UINodeMapSelector::renderSelectorEntry (int index, const std::string& data,
 		return;*/
 
 	if (!title.empty()) {
-		const BitmapFontPtr& font = getFont(title.length() > 15
-			? MEDIUM_FONT : HUGE_FONT);
-			// ? SMALL_FONT : MEDIUM_FONT);
+		const BitmapFontPtr& font = getFont(MEDIUM_FONT);
 		const int textHeight = font->getTextHeight(title);
-		// const int fontX = std::max(x, x + colWidth / 2 - font->getTextWidth(title) / 2);  // center
-		const int fontX = x;  // left
+		const int fontX = std::max(x, x + colWidth / 2 - font->getTextWidth(title) / 2);  // center
 		const int fontY = y + rowHeight - textHeight - 1 - padding;
 		
 		_frontend->renderFilledRect(x, fontY - 1, colWidth - padding, textHeight + 2, colorBlack);

--- a/src/modules/ui/nodes/UINodeMapSelector.cpp
+++ b/src/modules/ui/nodes/UINodeMapSelector.cpp
@@ -3,10 +3,13 @@
 #include "common/CommandSystem.h"
 #include "campaign/CampaignManager.h"
 #include "common/Commands.h"
+#include "ui/windows/UIMapSelectorWindow.h"
 #include <SDL_assert.h>
 
-UINodeMapSelector::UINodeMapSelector (IFrontend *frontend, const IMapManager &mapManager, bool multiplayer, int cols, int rows) :
-		UINodeBackgroundSelector<std::string>(frontend, cols, rows), _campaignManager(nullptr), _mapManager(&mapManager), _multiplayer(multiplayer)
+UINodeMapSelector::UINodeMapSelector (UIMapSelectorWindow* window,
+	IFrontend *frontend, const IMapManager &mapManager, bool multiplayer, int cols, int rows) :
+		UINodeBackgroundSelector<std::string>(frontend, cols, rows), _window(window),
+		_campaignManager(nullptr), _mapManager(&mapManager), _multiplayer(multiplayer)
 {
 	// setColsRowsFromTexture("map-icon-locked");
 	defaults();
@@ -14,9 +17,10 @@ UINodeMapSelector::UINodeMapSelector (IFrontend *frontend, const IMapManager &ma
 	reset();
 }
 
-UINodeMapSelector::UINodeMapSelector (IFrontend *frontend, CampaignManager &campaignManager, bool multiplayer, int cols, int rows) :
-		UINodeBackgroundSelector<std::string>(frontend, cols, rows), _campaignManager(&campaignManager), _mapManager(
-				nullptr), _multiplayer(multiplayer)
+UINodeMapSelector::UINodeMapSelector (UIMapSelectorWindow* window,
+	IFrontend *frontend, CampaignManager &campaignManager, bool multiplayer, int cols, int rows) :
+		UINodeBackgroundSelector<std::string>(frontend, cols, rows), _window(window),
+		_campaignManager(&campaignManager), _mapManager(nullptr), _multiplayer(multiplayer)
 {
 	// setColsRowsFromTexture("map-icon-locked");
 	defaults();
@@ -62,6 +66,11 @@ void UINodeMapSelector::renderSelectorEntry (int index, const std::string& data,
 		title = map->getName();
 	}
 
+	// update top title with selected map
+	if (_selectedIndex == index) {
+		_window->setTextDetails(title);
+	}
+
 	const int marginX = 25, padding = 20, marginXtotal = 2 * marginX + padding;
 	const TexturePtr t = getIcon(data);
 	if (_campaignManager != nullptr) {
@@ -69,9 +78,9 @@ void UINodeMapSelector::renderSelectorEntry (int index, const std::string& data,
 		const CampaignMap *map = campaignPtr->getMapById(data);
 		if (map != nullptr && !map->isLocked()) {
 
-			const BitmapFontPtr& font = getFont(LARGE_FONT);  // MEDIUM_FONT);
+			const BitmapFontPtr& font = getFont(LARGE_FONT);
 			const std::string points = string::toString(map->getFinishPoints());
-			const int fontX = std::max(x, x - padding / 2 + colWidth / 2 - font->getTextWidth(points) / 2 - padding / 2);
+			const int fontX = std::max(x, x + colWidth / 2 - font->getTextWidth(points) / 2 - padding / 2);
 			const int fontHeight = 22;
 			const int fontY = y;
 			if (t)
@@ -90,11 +99,10 @@ void UINodeMapSelector::renderSelectorEntry (int index, const std::string& data,
 	if (!title.empty()) {
 		const BitmapFontPtr& font = getFont(MEDIUM_FONT);
 		const int textHeight = font->getTextHeight(title);
-		const int fontX = std::max(x, x + colWidth / 2 - font->getTextWidth(title) / 2);  // center
+		const int fontX = std::max(x, x + colWidth / 2 - font->getTextWidth(title) / 2 - padding / 2);
 		const int fontY = y + rowHeight - textHeight - 1 - padding;
 		
 		_frontend->renderFilledRect(x, fontY - 1, colWidth - padding, textHeight + 2, colorBlack);
-		//_frontend->renderRect(x, fontY - 1, colWidth, textHeight + 2, colorWhite);
 		font->printMax(title, colorWhite, fontX, fontY, colWidth);
 	}
 }

--- a/src/modules/ui/nodes/UINodeMapSelector.h
+++ b/src/modules/ui/nodes/UINodeMapSelector.h
@@ -8,16 +8,18 @@
 // forward decl
 class IMapManager;
 class CampaignManager;
+class UIMapSelectorWindow;
 
 class UINodeMapSelector: public UINodeBackgroundSelector<std::string> {
 private:
+	UIMapSelectorWindow* _window;
 	CampaignManager *_campaignManager;
 	const IMapManager *_mapManager;
 	bool _multiplayer;
 public:
-	UINodeMapSelector (IFrontend *frontend, const IMapManager &mapManager, bool multiplayer = false,
+	UINodeMapSelector (UIMapSelectorWindow* window, IFrontend *frontend, const IMapManager &mapManager, bool multiplayer = false,
 		int cols = 6, int rows = 4);
-	UINodeMapSelector (IFrontend *frontend, CampaignManager &campaignManager, bool multiplayer = false,
+	UINodeMapSelector (UIMapSelectorWindow* window, IFrontend *frontend, CampaignManager &campaignManager, bool multiplayer = false,
 		int cols = 6, int rows = 4);
 	virtual ~UINodeMapSelector ();
 

--- a/src/modules/ui/nodes/UINodeMapSelector.h
+++ b/src/modules/ui/nodes/UINodeMapSelector.h
@@ -15,8 +15,10 @@ private:
 	const IMapManager *_mapManager;
 	bool _multiplayer;
 public:
-	UINodeMapSelector (IFrontend *frontend, const IMapManager &mapManager, bool multiplayer = false, int cols = 4, int rows = 2);
-	UINodeMapSelector (IFrontend *frontend, CampaignManager &campaignManager, bool multiplayer = false, int cols = 4, int rows = 2);
+	UINodeMapSelector (IFrontend *frontend, const IMapManager &mapManager, bool multiplayer = false,
+		int cols = 6, int rows = 4);
+	UINodeMapSelector (IFrontend *frontend, CampaignManager &campaignManager, bool multiplayer = false,
+		int cols = 6, int rows = 4);
 	virtual ~UINodeMapSelector ();
 
 	int getLives () const;

--- a/src/modules/ui/windows/UICampaignMapWindow.cpp
+++ b/src/modules/ui/windows/UICampaignMapWindow.cpp
@@ -5,7 +5,7 @@
 #include "ui/windows/campaignmapwindow/ResetCampaignListener.h"
 
 UICampaignMapWindow::UICampaignMapWindow (IFrontend *frontend, CampaignManager &campaignManager) :
-	UIMapSelectorWindow(new UINodeMapSelector(frontend, campaignManager), tr("Maps"), UI_WINDOW_CAMPAIGN_MAPS, frontend, WINDOW_FLAG_FULLSCREEN | WINDOW_FLAG_MAIN)
+	UIMapSelectorWindow(new UINodeMapSelector(this, frontend, campaignManager), tr("Maps"), UI_WINDOW_CAMPAIGN_MAPS, frontend, WINDOW_FLAG_FULLSCREEN | WINDOW_FLAG_MAIN)
 {
 #if 0
 	UINodeButton *resetButton = new UINodeButton(frontend);

--- a/src/modules/ui/windows/UICreateServerWindow.cpp
+++ b/src/modules/ui/windows/UICreateServerWindow.cpp
@@ -4,7 +4,7 @@
 #include "ui/UI.h"
 
 UICreateServerWindow::UICreateServerWindow (IFrontend *frontend, const IMapManager &mapManager) :
-		UIMapSelectorWindow(new UINodeMapSelector(frontend, mapManager, true), tr("Create server"), UI_WINDOW_CREATE_SERVER, frontend)
+		UIMapSelectorWindow(new UINodeMapSelector(this, frontend, mapManager, true), tr("Create server"), UI_WINDOW_CREATE_SERVER, frontend)
 {
 	// TODO: multiplayer options like a password and a max client setting
 }

--- a/src/modules/ui/windows/UIMapSelectorWindow.cpp
+++ b/src/modules/ui/windows/UIMapSelectorWindow.cpp
@@ -1,8 +1,10 @@
 #include "UIMapSelectorWindow.h"
+#include "ui/nodes/UINode.h"
 #include "ui/nodes/UINodeBackButton.h"
 #include "ui/nodes/UINodeButton.h"
 #include "ui/nodes/UINodeButtonImage.h"
 #include "ui/nodes/UINodeSprite.h"
+#include "ui/nodes/UINodeLabel.h"
 #include "ui/windows/listener/SelectorPageListener.h"
 #include "ui/UI.h"
 #include "common/SpriteDefinition.h"
@@ -17,6 +19,13 @@ UIMapSelectorWindow::UIMapSelectorWindow (UINodeMapSelector* mapSelector, const 
 {
 	UINodeBackground *background = new UINodeBackground(frontend, title);
 	add(background);
+
+	_textDetails = new UINodeLabel(frontend, "");
+	_textDetails->setAlignment(NODE_ALIGN_CENTER);
+	_textDetails->setPos(0.5f, 0.1f);  // below title
+	_textDetails->setFont(LARGE_FONT);
+	_textDetails->setColor(colorWhite);
+	add(_textDetails);
 
 	const float gap = 0.001f;
 
@@ -60,6 +69,11 @@ void UIMapSelectorWindow::update (uint32_t deltaTime)
 	UIWindow::update(deltaTime);
 	_buttonRight->setVisible(_mapSelector->hasMoreEntries());
 	_buttonLeft->setVisible(_mapSelector->hasLessEntries());
+}
+
+void UIMapSelectorWindow::setTextDetails (const std::string& text)
+{
+	_textDetails->setLabel(text);
 }
 
 void UIMapSelectorWindow::onActive ()

--- a/src/modules/ui/windows/UIMapSelectorWindow.h
+++ b/src/modules/ui/windows/UIMapSelectorWindow.h
@@ -2,11 +2,13 @@
 
 #include "ui/windows/UIWindow.h"
 #include "sprites/Sprite.h"
+#include <string>
 
 // forward decl
 class UINodeMapSelector;
 class UINodeButton;
 class UINodeSprite;
+class UINodeLabel;
 
 class UIMapSelectorWindow: public UIWindow {
 protected:
@@ -14,6 +16,7 @@ protected:
 	UINodeButton *_buttonLeft;
 	UINodeButton *_buttonRight;
 	UINodeSprite *_livesSprite;
+	UINodeLabel *_textDetails;
 	SpritePtr _liveSprite;
 public:
 	UIMapSelectorWindow (UINodeMapSelector* mapSelector, const std::string& title, const std::string& id, IFrontend *frontend, WindowFlags flags =
@@ -23,4 +26,5 @@ public:
 	// UIWindow
 	void update (uint32_t deltaTime) override;
 	void onActive () override;
+	void setTextDetails (const std::string& text);
 };


### PR DESCRIPTION
This changes to bigger views. 6 x 4 maps / campaigns.
IMO the denser view is better for CavePacker, and here we don't even have campaigns with more than 24 maps.
Name text aligned left. Using bigger fonts, depending on map name length.

![08_00-38-43](https://github.com/user-attachments/assets/99b7412e-2517-40e0-948a-d643e48a361f)
![08_00-38-53](https://github.com/user-attachments/assets/b556b0e2-44e3-41ed-865c-4e66684c8eda)
