### PR TITLE
Gameplay: quick package consume

### DIFF
--- a/src/caveexpress/server/entities/Package.cpp
+++ b/src/caveexpress/server/entities/Package.cpp
@@ -59,8 +59,8 @@ void Package::update (uint32_t deltaTime)
 	}
 
 	if (isCollected()) {
-		setLinearDamping(0.0f);
-		setAngularDamping(0.0);
+		setLinearDamping(0.5f);
+		setAngularDamping(0.5f);
 	}
 
 	if (!_target) {
@@ -90,19 +90,21 @@ void Package::onContact (b2Contact* contact, IEntity* entity)
 {
 	const bool oldCollectedState = isCollected();
 	CollectableEntity::onContact(contact, entity);
+
+	if (isImpactVelocityMoreThan(contact, 1.1f))
+		_map.sendSound(getVisMask(), SoundTypes::SOUND_PACKAGE_COLLIDE, getPos());
+
 	if (!oldCollectedState && isCollected()) {
 		_addRopeJointTo = entity;
 	} else {
 		if (entity->isSolid() || entity->isStone() || entity->isPackage()) {
 			setLinearDamping(3.0f);
-			setAngularDamping(1.0);
-			if (isImpactVelocityMoreThan(contact, 1.5f))
-				_map.sendSound(getVisMask(), SoundTypes::SOUND_PACKAGE_COLLIDE, getPos());
+			setAngularDamping(1.0f);
 		} else if (entity->isBorder()) {
 			const Border *b = assert_cast<const Border*, const IEntity*>(entity);
 			if (!b->isTop()) {
 				setLinearDamping(4.0f);
-				setAngularDamping(1.0);
+				setAngularDamping(1.0f);
 			}
 		} else if (entity->isNpcAttacking()) {
 			setDestroyed(true);
@@ -129,7 +131,7 @@ bool Package::setArrived (bool arrived)
 
 	if (_collectCount == 1 && _arrived) {
 		const uint32_t deltaSeconds = _time - _collectedTime;
-		return deltaSeconds < 4000;
+		return deltaSeconds < 1000;
 	}
 
 	return false;

--- a/src/caveexpress/server/entities/PackageTarget.cpp
+++ b/src/caveexpress/server/entities/PackageTarget.cpp
@@ -7,7 +7,7 @@
 
 namespace caveexpress {
 
-#define LENGTH_UPDATE_DELAY 500
+#define LENGTH_UPDATE_DELAY 50
 
 PackageTarget::PackageTarget (Map& map, const std::string& spriteID, gridCoord x, gridCoord y) :
 		MapTile(map, spriteID, x, y,


### PR DESCRIPTION
Also added more sounds on package hitting anything else.
This makes the package gameplay much quicker, no need to wait few seconds for each to get consumed.
It is almost instant. Would be cool to have some particles. But either way I prefer this quicker gameplay, is IMO more fun. Again focuses more on flying rather than waiting or managing packages at their target. Can now easily get 3 packages and having them attached get them all consumed by flying a bit and not even dropping them.
I did play with even `LENGTH_UPDATE_DELAY 5`, but that was just too instant.