### PR TITLE
switch to maps view 6x4 for big screens

### DIFF
--- a/src/modules/ui/nodes/UINodeCampaignSelector.cpp
+++ b/src/modules/ui/nodes/UINodeCampaignSelector.cpp
@@ -55,7 +55,7 @@ void UINodeCampaignSelector::renderSelectorEntry (int index, const CampaignPtr& 
 			renderImage(t, x, y, colWidth, rowHeight, alpha);
 		}
 	}else{
-		const int marginX = 35, padding = 20, marginXtotal = 2 * marginX + padding;
+		const int marginX = 7 * colWidth / 50, padding = 4 * colWidth / 50, marginXtotal = 2 * marginX + padding;
 		if (!data->getText().empty()) {
 
 			const BitmapFontPtr& font = getFont(HUGE_FONT);

--- a/src/modules/ui/nodes/UINodeCampaignSelector.cpp
+++ b/src/modules/ui/nodes/UINodeCampaignSelector.cpp
@@ -42,16 +42,33 @@ void UINodeCampaignSelector::renderSelectorEntry (int index, const CampaignPtr& 
 	if (!t || !t->isValid())
 		t = loadTexture("icon-campaign");
 
-	if (!data->getText().empty()) {
-		const BitmapFontPtr& font = getFont(HUGE_FONT);
-		const int textHeight = font->getTextHeight(data->getText());
-		const int fontX = std::max(x, x + colWidth / 2 - font->getTextWidth(data->getText()) / 2);
-		const int fontY = y + rowHeight - textHeight - 1;
-		renderFilledRect(x, fontY - 1, colWidth - _padding, textHeight + 2, colorBlack);
-		renderImage(t, x, y, colWidth, rowHeight - textHeight, alpha);
-		font->printMax(data->getText(), colorWhite, fontX, fontY, colWidth);
-	} else {
-		renderImage(t, x, y, colWidth, rowHeight, alpha);
+	if (isSmallScreen()) {
+		if (!data->getText().empty()) {
+			const BitmapFontPtr& font = getFont(HUGE_FONT);
+			const int textHeight = font->getTextHeight(data->getText());
+			const int fontX = std::max(x, x + colWidth / 2 - font->getTextWidth(data->getText()) / 2);
+			const int fontY = y + rowHeight - textHeight - 1;
+			renderFilledRect(x, fontY - 1, colWidth - _padding, textHeight + 2, colorBlack);
+			renderImage(t, x, y, colWidth, rowHeight - textHeight, alpha);
+			font->printMax(data->getText(), colorWhite, fontX, fontY, colWidth);
+		} else {
+			renderImage(t, x, y, colWidth, rowHeight, alpha);
+		}
+	}else{
+		const int marginX = 35, padding = 20, marginXtotal = 2 * marginX + padding;
+		if (!data->getText().empty()) {
+
+			const BitmapFontPtr& font = getFont(HUGE_FONT);
+			const int textHeight = font->getTextHeight(data->getText());
+			const int fontX = std::max(x, x + colWidth / 2 - font->getTextWidth(data->getText()) / 2 - padding / 2 );
+			const int fontY = y + rowHeight - textHeight - 1 - padding;
+
+			_frontend->renderFilledRect(x, fontY - 1, colWidth - padding, textHeight + 2, colorBlack);
+			renderImage(t, x + marginX, y, colWidth - marginXtotal, rowHeight - textHeight - padding, alpha);
+			font->printMax(data->getText(), colorWhite, fontX, fontY, colWidth);
+		} else {
+			renderImage(t, x + marginX, y, colWidth - marginXtotal, rowHeight - padding, alpha);
+		}
 	}
 }
 

--- a/src/modules/ui/nodes/UINodeMapSelector.cpp
+++ b/src/modules/ui/nodes/UINodeMapSelector.cpp
@@ -109,7 +109,7 @@ void UINodeMapSelector::renderSelectorEntry (int index, const std::string& data,
 			font->printMax(title, colorWhite, fontX, fontY, colWidth);
 		}
 	} else {  // big 6 x 4
-		const int marginX = 25, padding = 20, marginXtotal = 2 * marginX + padding;
+		const int marginX = 5 * colWidth / 50, padding = 4 * colWidth / 50, marginXtotal = 2 * marginX + padding;
 		const TexturePtr t = getIcon(data);
 		if (_campaignManager != nullptr) {
 			const CampaignPtr& campaignPtr = _campaignManager->getActiveCampaign();
@@ -117,9 +117,10 @@ void UINodeMapSelector::renderSelectorEntry (int index, const std::string& data,
 			if (map != nullptr && !map->isLocked()) {
 
 				const BitmapFontPtr& font = getFont(LARGE_FONT);
+				const int textHeight = font->getTextHeight(title);
 				const std::string points = string::toString(map->getFinishPoints());
 				const int fontX = std::max(x, x + colWidth / 2 - font->getTextWidth(points) / 2 - padding / 2);
-				const int fontHeight = 22;
+				const int fontHeight = 22 * textHeight / 64;
 				const int fontY = y;
 				if (t)
 					renderImage(t, x + marginX, y, colWidth - marginXtotal, rowHeight - fontHeight - padding, alpha);

--- a/src/modules/ui/nodes/UINodeMapSelector.cpp
+++ b/src/modules/ui/nodes/UINodeMapSelector.cpp
@@ -6,8 +6,10 @@
 #include "ui/windows/UIMapSelectorWindow.h"
 #include <SDL_assert.h>
 
-UINodeMapSelector::UINodeMapSelector (UIMapSelectorWindow* window, IFrontend *frontend, const IMapManager &mapManager, bool multiplayer, int cols, int rows) :
-		UINodeBackgroundSelector<std::string>(frontend, cols, rows), _window(window), _campaignManager(nullptr), _mapManager(&mapManager), _multiplayer(multiplayer)
+UINodeMapSelector::UINodeMapSelector (UIMapSelectorWindow* window,
+	IFrontend *frontend, const IMapManager &mapManager, bool multiplayer, int cols, int rows) :
+		UINodeBackgroundSelector<std::string>(frontend, cols, rows), _window(window),
+		_campaignManager(nullptr), _mapManager(&mapManager), _multiplayer(multiplayer)
 {
 	onWindowResize();
 	defaults();
@@ -15,9 +17,10 @@ UINodeMapSelector::UINodeMapSelector (UIMapSelectorWindow* window, IFrontend *fr
 	reset();
 }
 
-UINodeMapSelector::UINodeMapSelector (UIMapSelectorWindow* window, IFrontend *frontend, CampaignManager &campaignManager, bool multiplayer, int cols, int rows) :
-		UINodeBackgroundSelector<std::string>(frontend, cols, rows), _window(window), _campaignManager(&campaignManager), _mapManager(
-				nullptr), _multiplayer(multiplayer)
+UINodeMapSelector::UINodeMapSelector (UIMapSelectorWindow* window,
+	IFrontend *frontend, CampaignManager &campaignManager, bool multiplayer, int cols, int rows) :
+		UINodeBackgroundSelector<std::string>(frontend, cols, rows), _window(window),
+		_campaignManager(&campaignManager), _mapManager(nullptr), _multiplayer(multiplayer)
 {
 	onWindowResize();
 	defaults();
@@ -73,36 +76,72 @@ void UINodeMapSelector::renderSelectorEntry (int index, const std::string& data,
 		_window->setTextDetails(title);
 	}
 
-	const TexturePtr t = getIcon(data);
-	if (_campaignManager != nullptr) {
-		const CampaignPtr& campaignPtr = _campaignManager->getActiveCampaign();
-		const CampaignMap *map = campaignPtr->getMapById(data);
-		if (map != nullptr && !map->isLocked()) {
-			const BitmapFontPtr& font = getFont(MEDIUM_FONT);
-			const std::string points = string::toString(map->getFinishPoints());
-			const int fontX = std::max(x, x + colWidth / 2 - font->getTextWidth(points) / 2);
-			const int fontHeight = font->getTextHeight(points);
-			const int fontY = y + fontHeight;
-			if (t)
-				renderImage(t, x, y, colWidth, rowHeight - fontHeight, alpha);
-			font->printMax(points, colorWhite, fontX, fontY, colWidth);
+	if (isSmallScreen()) {  // small
+		const TexturePtr t = getIcon(data);
+		if (_campaignManager != nullptr) {
+			const CampaignPtr& campaignPtr = _campaignManager->getActiveCampaign();
+			const CampaignMap *map = campaignPtr->getMapById(data);
+			if (map != nullptr && !map->isLocked()) {
+				const BitmapFontPtr& font = getFont(MEDIUM_FONT);
+				const std::string points = string::toString(map->getFinishPoints());
+				const int fontX = std::max(x, x + colWidth / 2 - font->getTextWidth(points) / 2);
+				const int fontHeight = font->getTextHeight(points);
+				const int fontY = y + fontHeight;
+				if (t)
+					renderImage(t, x, y, colWidth, rowHeight - fontHeight, alpha);
+				font->printMax(points, colorWhite, fontX, fontY, colWidth);
+			} else if (t) {
+				renderImage(t, x, y, colWidth, rowHeight, alpha);
+			}
 		} else if (t) {
 			renderImage(t, x, y, colWidth, rowHeight, alpha);
 		}
-	} else if (t) {
-		renderImage(t, x, y, colWidth, rowHeight, alpha);
-	}
 
-/*	if (_selectedIndex != index)
-		return;*/
+	/*	if (_selectedIndex != index)
+			return;*/
 
-	if (!title.empty()) {
-		const BitmapFontPtr& font = getFont(MEDIUM_FONT);
-		const int textHeight = font->getTextHeight(title);
-		const int fontX = std::max(x, x + colWidth / 2 - font->getTextWidth(title) / 2);
-		const int fontY = y + rowHeight - textHeight - 1;
-		_frontend->renderFilledRect(x, fontY - 1, colWidth, textHeight + 2, colorBlack);
-		font->printMax(title, colorWhite, fontX, fontY, colWidth);
+		if (!title.empty()) {
+			const BitmapFontPtr& font = getFont(MEDIUM_FONT);
+			const int textHeight = font->getTextHeight(title);
+			const int fontX = std::max(x, x + colWidth / 2 - font->getTextWidth(title) / 2);
+			const int fontY = y + rowHeight - textHeight - 1;
+			_frontend->renderFilledRect(x, fontY - 1, colWidth, textHeight + 2, colorBlack);
+			font->printMax(title, colorWhite, fontX, fontY, colWidth);
+		}
+	} else {  // big 6 x 4
+		const int marginX = 25, padding = 20, marginXtotal = 2 * marginX + padding;
+		const TexturePtr t = getIcon(data);
+		if (_campaignManager != nullptr) {
+			const CampaignPtr& campaignPtr = _campaignManager->getActiveCampaign();
+			const CampaignMap *map = campaignPtr->getMapById(data);
+			if (map != nullptr && !map->isLocked()) {
+
+				const BitmapFontPtr& font = getFont(LARGE_FONT);
+				const std::string points = string::toString(map->getFinishPoints());
+				const int fontX = std::max(x, x + colWidth / 2 - font->getTextWidth(points) / 2 - padding / 2);
+				const int fontHeight = 22;
+				const int fontY = y;
+				if (t)
+					renderImage(t, x + marginX, y, colWidth - marginXtotal, rowHeight - fontHeight - padding, alpha);
+				font->printMax(points, colorWhite, fontX, fontY, colWidth);
+			} else if (t) {
+				renderImage(t, x + marginX, y, colWidth - marginXtotal, rowHeight - padding, alpha);
+			}
+		} else if (t) {
+			renderImage(t, x + marginX, y, colWidth - marginXtotal, rowHeight - padding, alpha);
+		}
+	/*	if (_selectedIndex != index)
+			return;*/
+
+		if (!title.empty()) {
+			const BitmapFontPtr& font = getFont(MEDIUM_FONT);
+			const int textHeight = font->getTextHeight(title);
+			const int fontX = std::max(x, x + colWidth / 2 - font->getTextWidth(title) / 2 - padding / 2);
+			const int fontY = y + rowHeight - textHeight - 1 - padding;
+			
+			_frontend->renderFilledRect(x, fontY - 1, colWidth - padding, textHeight + 2, colorBlack);
+			font->printMax(title, colorWhite, fontX, fontY, colWidth);
+		}
 	}
 }
 

--- a/src/modules/ui/nodes/UINodeSelector.h
+++ b/src/modules/ui/nodes/UINodeSelector.h
@@ -110,12 +110,18 @@ public:
 		const TexturePtr& refPicForSelector = loadTexture(refTexture);
 		if (!refPicForSelector->isValid())
 			return;
-		const int rw = getRenderWidth(true);
-		const int rh = getRenderHeight(true);
-		const int cols = std::max(1, rw / refPicForSelector->getWidth());
-		const int rows = std::max(1, rh / refPicForSelector->getHeight());
-		setLayoutData(cols, rows, refPicForSelector->getWidth() / static_cast<float>(_frontend->getWidth()),
-				refPicForSelector->getHeight() / static_cast<float>(_frontend->getHeight()));
+		
+		if (isSmallScreen()) {
+			const int rw = getRenderWidth(true);
+			const int rh = getRenderHeight(true);
+			const int cols = std::max(1, rw / refPicForSelector->getWidth());
+			const int rows = std::max(1, rh / refPicForSelector->getHeight());
+			setLayoutData(cols, rows, refPicForSelector->getWidth() / static_cast<float>(_frontend->getWidth()),
+					refPicForSelector->getHeight() / static_cast<float>(_frontend->getHeight()));
+		}else{
+			setLayoutData(_cols, _rows, refPicForSelector->getWidth() / static_cast<float>(_frontend->getWidth()),
+					refPicForSelector->getHeight() * 3 / 4 / static_cast<float>(_frontend->getHeight()));
+		}
 	}
 
 	inline void setLayoutData (int cols, int rows, float colWidth, float rowHeight)


### PR DESCRIPTION
Small screen stays like now but for big (on PC) this basically restores what I did in #131, that 6x4 view of maps and campaigns.
I didn't test on other resolutions.
